### PR TITLE
Add meditation calendar tracking

### DIFF
--- a/.idea/copyright/Default.xml
+++ b/.idea/copyright/Default.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="&amp;#36;file.fileName&#10;Copyright (C) 2014-&amp;#36;today.year BodhiTimer developers&#10;&#10;Distributed under terms of the GNU GPLv3 license." />
+    <option name="notice" value="&amp;#36;file.fileName&#10;Copyright (C) 2014-&amp;#36;today.year DivineTimer developers&#10;&#10;Distributed under terms of the GNU GPLv3 license." />
     <option name="myName" value="Default" />
   </copyright>
 </component>

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,7 +1,7 @@
 
 ## Privacy policy
 
-**Bodhi Timer does not collect, log or share your personal information.**
+**Divine Timer does not collect, log or share your personal information.**
 
 
 The timer stores your settings on the device, they are never uploaded or shared anywhere.

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/AdvNumberPicker.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/AdvNumberPicker.kt
@@ -1,6 +1,6 @@
 /*
  * AdvNumberPicker.java
- * Copyright (C) 2014-2022 BodhiTimer developers
+ * Copyright (C) 2014-2022 DivineTimer developers
  *
  * Distributed under terms of the GNU GPLv3 license.
  */

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Animation/BodhiLeaf.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Animation/BodhiLeaf.kt
@@ -1,18 +1,18 @@
 /*
-    This file is part of Bodhi Timer.
+    This file is part of Divine Timer.
 
-    Bodhi Timer is free software: you can redistribute it and/or modify
+    Divine Timer is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Bodhi Timer is distributed in the hope that it will be useful,
+    Divine Timer is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Bodhi Timer.  If not, see <http://www.gnu.org/licenses/>.
+    along with Divine Timer.  If not, see <http://www.gnu.org/licenses/>.
 */
 package org.yuttadhammo.BodhiTimer.Animation
 

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Animation/CircleAnimation.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Animation/CircleAnimation.kt
@@ -1,18 +1,18 @@
 /*
-    This file is part of Bodhi Timer.
+    This file is part of Divine Timer.
 
-    Bodhi Timer is free software: you can redistribute it and/or modify
+    Divine Timer is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Bodhi Timer is distributed in the hope that it will be useful,
+    Divine Timer is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Bodhi Timer.  If not, see <http://www.gnu.org/licenses/>.
+    along with Divine Timer.  If not, see <http://www.gnu.org/licenses/>.
 */
 package org.yuttadhammo.BodhiTimer.Animation
 

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Animation/TimerAnimation.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Animation/TimerAnimation.kt
@@ -1,18 +1,18 @@
 /*
-    This file is part of Bodhi Timer.
+    This file is part of Divine Timer.
 
-    Bodhi Timer is free software: you can redistribute it and/or modify
+    Divine Timer is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Bodhi Timer is distributed in the hope that it will be useful,
+    Divine Timer is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Bodhi Timer.  If not, see <http://www.gnu.org/licenses/>.
+    along with Divine Timer.  If not, see <http://www.gnu.org/licenses/>.
 */
 package org.yuttadhammo.BodhiTimer.Animation
 

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/BodhiApp.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/BodhiApp.kt
@@ -1,6 +1,6 @@
 /*
  * BodhiApp.kt
- * Copyright (C) 2014-2022 BodhiTimer developers
+ * Copyright (C) 2014-2022 DivineTimer developers
  *
  * Distributed under terms of the GNU GPLv3 license.
  */

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Models/AlarmTaskManager.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Models/AlarmTaskManager.kt
@@ -22,6 +22,7 @@ import org.yuttadhammo.BodhiTimer.Const.TimerState.STOPPED
 import org.yuttadhammo.BodhiTimer.Const.TimerState.getText
 import org.yuttadhammo.BodhiTimer.Service.SoundService
 import org.yuttadhammo.BodhiTimer.Util.Settings
+import org.yuttadhammo.BodhiTimer.Util.MeditationLog
 import org.yuttadhammo.BodhiTimer.Util.Time
 import timber.log.Timber
 import java.util.Date
@@ -465,6 +466,8 @@ class AlarmTaskManager(private val mApp: Application) : AndroidViewModel(mApp) {
 
         // Update labels
         if (alarms.empty()) {
+            // Log session if it was at least ten minutes
+            MeditationLog.logSession(sessionDuration)
             stopAlarmsAndTicker()
             loadLastTimers()
             // Reschedule alarms in case AutoRestart is active

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Service/TTSService.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Service/TTSService.kt
@@ -1,18 +1,18 @@
 /*
-    This file is part of Bodhi Timer.
+    This file is part of Divine Timer.
 
-    Bodhi Timer is free software: you can redistribute it and/or modify
+    Divine Timer is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Bodhi Timer is distributed in the hope that it will be useful,
+    Divine Timer is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Bodhi Timer.  If not, see <http://www.gnu.org/licenses/>.
+    along with Divine Timer.  If not, see <http://www.gnu.org/licenses/>.
 */
 package org.yuttadhammo.BodhiTimer.Service
 

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Service/TimerReceiver.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Service/TimerReceiver.kt
@@ -1,18 +1,18 @@
 /*
-    This file is part of Bodhi Timer.
+    This file is part of Divine Timer.
 
-    Bodhi Timer is free software: you can redistribute it and/or modify
+    Divine Timer is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Bodhi Timer is distributed in the hope that it will be useful,
+    Divine Timer is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Bodhi Timer.  If not, see <http://www.gnu.org/licenses/>.
+    along with Divine Timer.  If not, see <http://www.gnu.org/licenses/>.
 */
 package org.yuttadhammo.BodhiTimer.Service
 

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/SettingsFragment.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/SettingsFragment.kt
@@ -1,6 +1,6 @@
 /*
  * SettingsFragment.kt
- * Copyright (C) 2014-2022 BodhiTimer developers
+ * Copyright (C) 2014-2022 DivineTimer developers
  *
  * Distributed under terms of the GNU GPLv3 license.
  */

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/SlidingPickerDialog.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/SlidingPickerDialog.kt
@@ -1,6 +1,6 @@
 /*
  * SlidingPickerView.kt
- * Copyright (C) 2014-2022 BodhiTimer developers
+ * Copyright (C) 2014-2022 DivineTimer developers
  *
  * Distributed under terms of the GNU GPLv3 license.
  */

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/TimerActivity.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/TimerActivity.kt
@@ -1,6 +1,6 @@
 /*
  * TimerActivity.kt
- * Copyright (C) 2014-2022 BodhiTimer developers
+ * Copyright (C) 2014-2022 DivineTimer developers
  *
  * Distributed under terms of the GNU GPLv3 license.
  */
@@ -40,6 +40,7 @@ import org.yuttadhammo.BodhiTimer.Models.TimerList
 import org.yuttadhammo.BodhiTimer.Util.Notifications.createNotificationChannel
 import org.yuttadhammo.BodhiTimer.Util.Settings
 import org.yuttadhammo.BodhiTimer.Util.Themes
+import org.yuttadhammo.BodhiTimer.Util.MeditationLog
 import org.yuttadhammo.BodhiTimer.Util.Time
 import org.yuttadhammo.BodhiTimer.Util.Time.msFromArray
 import org.yuttadhammo.BodhiTimer.Util.Time.str2complexTimeString
@@ -71,6 +72,7 @@ class TimerActivity : AppCompatActivity(), View.OnClickListener, OnSharedPrefere
     private lateinit var mBottomNavigation: com.google.android.material.bottomnavigation.BottomNavigationView
     private lateinit var mTimerGroup: androidx.constraintlayout.widget.Group
     private lateinit var mInfoView: View
+    private lateinit var mCalendarView: android.widget.CalendarView
 
     var mAlarmTaskManager: AlarmTaskManager? = null
 
@@ -162,21 +164,40 @@ class TimerActivity : AppCompatActivity(), View.OnClickListener, OnSharedPrefere
         mBottomNavigation = findViewById(R.id.bottom_navigation)
         mTimerGroup = findViewById(R.id.timer_group)
         mInfoView = findViewById(R.id.info_view)
+        mCalendarView = findViewById(R.id.calendar_view)
+
+        mCalendarView.setOnDateChangeListener { _, year, month, dayOfMonth ->
+            val cal = java.util.Calendar.getInstance()
+            cal.set(year, month, dayOfMonth, 0, 0, 0)
+            cal.set(java.util.Calendar.MILLISECOND, 0)
+            MeditationLog.toggleDate(cal.timeInMillis)
+            val msg = if (MeditationLog.isLogged(cal.timeInMillis)) R.string.log_added else R.string.log_removed
+            android.widget.Toast.makeText(this, getString(msg), android.widget.Toast.LENGTH_SHORT).show()
+        }
 
         mBottomNavigation.selectedItemId = R.id.nav_timer
         mTimerGroup.visibility = View.VISIBLE
         mInfoView.visibility = View.GONE
+        mCalendarView.visibility = View.GONE
 
         mBottomNavigation.setOnItemSelectedListener {
             when (it.itemId) {
                 R.id.nav_timer -> {
                     mTimerGroup.visibility = View.VISIBLE
                     mInfoView.visibility = View.GONE
+                    mCalendarView.visibility = View.GONE
                     true
                 }
                 R.id.nav_info -> {
                     mTimerGroup.visibility = View.GONE
                     mInfoView.visibility = View.VISIBLE
+                    mCalendarView.visibility = View.GONE
+                    true
+                }
+                R.id.nav_calendar -> {
+                    mTimerGroup.visibility = View.GONE
+                    mInfoView.visibility = View.GONE
+                    mCalendarView.visibility = View.VISIBLE
                     true
                 }
                 else -> false

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Util/MeditationLog.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Util/MeditationLog.kt
@@ -1,0 +1,42 @@
+package org.yuttadhammo.BodhiTimer.Util
+
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import org.yuttadhammo.BodhiTimer.BodhiApp
+import java.text.SimpleDateFormat
+import java.util.*
+
+object MeditationLog {
+    private const val KEY_LOG = "meditation_log"
+
+    private val prefs: SharedPreferences
+        get() = PreferenceManager.getDefaultSharedPreferences(BodhiApp.applicationContext())
+
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+
+    fun logSession(duration: Int, time: Long = System.currentTimeMillis()) {
+        if (duration < 10 * 60 * 1000) return
+        logDate(time)
+    }
+
+    fun logDate(time: Long) {
+        val set = prefs.getStringSet(KEY_LOG, mutableSetOf())!!.toMutableSet()
+        set.add(dateFormat.format(Date(time)))
+        prefs.edit().putStringSet(KEY_LOG, set).apply()
+    }
+
+    fun toggleDate(time: Long) {
+        val set = prefs.getStringSet(KEY_LOG, mutableSetOf())!!.toMutableSet()
+        val date = dateFormat.format(Date(time))
+        if (set.contains(date)) set.remove(date) else set.add(date)
+        prefs.edit().putStringSet(KEY_LOG, set).apply()
+    }
+
+    fun isLogged(time: Long): Boolean {
+        val set = prefs.getStringSet(KEY_LOG, emptySet())
+        val date = dateFormat.format(Date(time))
+        return set?.contains(date) == true
+    }
+
+    fun allLoggedDates(): Set<String> = prefs.getStringSet(KEY_LOG, emptySet()) ?: emptySet()
+}

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Util/Themes.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Util/Themes.kt
@@ -1,6 +1,6 @@
 /*
  * Themes.kt
- * Copyright (C) 2014-2022 BodhiTimer developers
+ * Copyright (C) 2014-2022 DivineTimer developers
  *
  * Distributed under terms of the GNU GPLv3 license.
  */

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Util/Time.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Util/Time.kt
@@ -1,6 +1,6 @@
 /*
  * Time.kt
- * Copyright (C) 2014-2022 BodhiTimer developers
+ * Copyright (C) 2014-2022 DivineTimer developers
  *
  * Distributed under terms of the GNU GPLv3 license.
  */

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/Widget/BodhiAppWidgetProvider.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/Widget/BodhiAppWidgetProvider.kt
@@ -1,18 +1,18 @@
 /*
-    This file is part of Bodhi Timer.
+    This file is part of Divine Timer.
 
-    Bodhi Timer is free software: you can redistribute it and/or modify
+    Divine Timer is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Bodhi Timer is distributed in the hope that it will be useful,
+    Divine Timer is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Bodhi Timer.  If not, see <http://www.gnu.org/licenses/>.
+    along with Divine Timer.  If not, see <http://www.gnu.org/licenses/>.
 */
 package org.yuttadhammo.BodhiTimer.Widget
 

--- a/app/src/main/res/drawable-v24/ic_launcher_background.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_background.xml
@@ -1,6 +1,6 @@
 <!--
   ~ ic_launcher_background.xml
-  ~ Copyright (C) 2014-2022 BodhiTimer developers
+  ~ Copyright (C) 2014-2022 DivineTimer developers
   ~
   ~ Distributed under terms of the GNU GPLv3 license.
   -->

--- a/app/src/main/res/drawable/notification.xml
+++ b/app/src/main/res/drawable/notification.xml
@@ -1,6 +1,6 @@
 <!--
   ~ notification.xml
-  ~ Copyright (C) 2014-2022 BodhiTimer developers
+  ~ Copyright (C) 2014-2022 DivineTimer developers
   ~
   ~ Distributed under terms of the GNU GPLv3 license.
   -->

--- a/app/src/main/res/drawable/pause.xml
+++ b/app/src/main/res/drawable/pause.xml
@@ -1,6 +1,6 @@
 <!--
   ~ pause.xml
-  ~ Copyright (C) 2014-2022 BodhiTimer developers
+  ~ Copyright (C) 2014-2022 DivineTimer developers
   ~
   ~ Distributed under terms of the GNU GPLv3 license.
   -->

--- a/app/src/main/res/drawable/play.xml
+++ b/app/src/main/res/drawable/play.xml
@@ -1,6 +1,6 @@
 <!--
   ~ play.xml
-  ~ Copyright (C) 2014-2022 BodhiTimer developers
+  ~ Copyright (C) 2014-2022 DivineTimer developers
   ~
   ~ Distributed under terms of the GNU GPLv3 license.
   -->

--- a/app/src/main/res/drawable/preferences.xml
+++ b/app/src/main/res/drawable/preferences.xml
@@ -1,6 +1,6 @@
 <!--
   ~ preferences.xml
-  ~ Copyright (C) 2014-2022 BodhiTimer developers
+  ~ Copyright (C) 2014-2022 DivineTimer developers
   ~
   ~ Distributed under terms of the GNU GPLv3 license.
   -->

--- a/app/src/main/res/drawable/set.xml
+++ b/app/src/main/res/drawable/set.xml
@@ -1,6 +1,6 @@
 <!--
   ~ set.xml
-  ~ Copyright (C) 2014-2022 BodhiTimer developers
+  ~ Copyright (C) 2014-2022 DivineTimer developers
   ~
   ~ Distributed under terms of the GNU GPLv3 license.
   -->

--- a/app/src/main/res/drawable/stop.xml
+++ b/app/src/main/res/drawable/stop.xml
@@ -1,6 +1,6 @@
 <!--
   ~ stop.xml
-  ~ Copyright (C) 2014-2022 BodhiTimer developers
+  ~ Copyright (C) 2014-2022 DivineTimer developers
   ~
   ~ Distributed under terms of the GNU GPLv3 license.
   -->

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -149,6 +149,17 @@
             android:textSize="16sp" />
     </ScrollView>
 
+    <CalendarView
+        android:id="@+id/calendar_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        android:background="?attr/colorSurfaceInverse"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <androidx.constraintlayout.widget.Group
         android:id="@+id/timer_group"
         android:layout_width="wrap_content"

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -7,4 +7,8 @@
         android:id="@+id/nav_info"
         android:icon="@android:drawable/ic_menu_info_details"
         android:title="@string/tab_info" />
+    <item
+        android:id="@+id/nav_calendar"
+        android:icon="@android:drawable/ic_menu_my_calendar"
+        android:title="@string/tab_calendar" />
 </menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">Bodhi Timer</string>
+    <string name="app_name">Divine Timer</string>
     <string name="Stop">Zurücksetzen</string>
 
     <string name="Notification">Timer abgelaufen!</string>
@@ -59,13 +59,13 @@
     <string name="stay_awake">Wach bleiben</string>
     <string name="stay_awake_desc">Das Telefon nicht einschlafen lassen.</string>
 
-    <string name="about_desc">Über Bodhi Timer</string>
+    <string name="about_desc">Über Divine Timer</string>
 
 
     <!-- About -->
     <string name="close">Schließen</string>
     <string name="about">Info</string>
-    <string name="about_title">Über Bodhi Timer</string>
+    <string name="about_title">Über Divine Timer</string>
     <string name="set">Setzen</string>
     <string name="pause">Pause</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">Bodhi Timer</string>
+    <string name="app_name">Divine Timer</string>
     <string name="Stop">Effacer</string>
 
     <string name="prefs">Préférences</string>
@@ -20,7 +20,7 @@
     <!-- About -->
     <string name="close">Fermer</string>
     <string name="about">À propos</string>
-    <string name="about_title">À propos de Bodhi Timer</string>
+    <string name="about_title">À propos de Divine Timer</string>
     <string name="NoVoiceRecognitionInstalled">Veuillez installer une application de reconnaissance vocale !</string>
 
     </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -134,7 +134,7 @@ a {color: rgb(255,87,34); text-decoration: none;}
 
 <p>
 获取菩提计时器最新版的源代码可以访问:
-<a href=\"https://github.com/yuttadhammo/BodhiTimer\">BodhiTimer</a>。
+<a href=\"https://github.com/yuttadhammo/DivineTimer\">DivineTimer</a>。
 </p>
 
 <h4>感谢</h4>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">Bodhi Timer</string>
+    <string name="app_name">Divine Timer</string>
     <string name="Stop">Clear</string>
-    <string name="Notification">Bodhi Timer Finished</string>
+    <string name="Notification">Divine Timer Finished</string>
     <string name="timer_for_x">Timer for %s</string>
 
     <plurals name="x_hours">
@@ -90,30 +90,30 @@
     <string name="stay_awake_desc">Don\'t allow the phone to go to sleep.</string>
     <string name="switch_time">Switch Time Input Mode</string>
     <string name="switch_time_desc">Clicking on clock opens speech input (otherwise on long-click).</string>
-    <string name="about_desc">About Bodhi Timer</string>
+    <string name="about_desc">About Divine Timer</string>
 
 
     <!-- About -->
     <string name="close">Close</string>
     <string name="about">About</string>
-    <string name="about_title">About Bodhi Timer</string>
+    <string name="about_title">About Divine Timer</string>
     <string name="about_text">
 		<![CDATA[
 		    <style>
 		        a {color: rgb(255,87,34); text-decoration: none;}
 		    </style>
 			<body style="text-align:justify;font-size:16px;">
-				<p><b>Bodhi Timer</b> is an elegant, minimalist countdown timer.  It was designed mainly for use as a meditation timer but can easily be used for any similar purpose.</p>
+				<p><b>Divine Timer</b> is an elegant, minimalist countdown timer.  It was designed mainly for use as a meditation timer but can easily be used for any similar purpose.</p>
 				<p><b>Set the time</b> via the clock button in the top left corner.  You may <b>set presets</b> by choosing a time then holding down on one of the three preset buttons.</p>
 				<p>You may alternatively <b>use speech to set the time</b> by long-pressing the clock button.  These behaviours can be swapped via the preference screen.</p>
 				<p><b>To set multiple consecutive timers</b>, long-click on the "adv" button in the time set screen, then create a list of times, or simply use the speech recognition, separating each time with the word "again". For example, say &quot;<b>thirty minutes again one hour</b>&quot; to set two consecutive timers, first for thirty minutes then for one hour.</p>
 				<p><b>Pause/resume</b> via the buttons in the bottom left corner and stop the timer via the button in the bottom right.  <b>Change preferences</b> via the top-right button.</p>
 				<p>Animation may be toggled between a fade-in Bodhi Leaf or a animated Enso brush drawing, chosen from the preferences screen.  The Bodhi leaf may also be substituted for a custom image via the preferences screen.</p>
 				<p>You may <b>add a timer widget</b> to your desktop via the App Drawer, or on your lockscreen (Android 4.2+).</p>
-				<p><b>Bodhi Timer</b> is free and open source software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version. <b><a href="http://www.gnu.org/licenses/gpl.html">GPL License</a></b></p>
-				<p>Get the latest version of the source code <b><a href="https://github.com/yuttadhammo/BodhiTimer">on GitHub</a></b>.</p>
+				<p><b>Divine Timer</b> is free and open source software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version. <b><a href="http://www.gnu.org/licenses/gpl.html">GPL License</a></b></p>
+				<p>Get the latest version of the source code <b><a href="https://github.com/yuttadhammo/DivineTimer">on GitHub</a></b>.</p>
 				<h4>Credits</h4>
-				<p>Bodhi Timer is a fork of the open source TeaTimer app by Ralph Gootee, which is also available <b><a href="https://github.com/ralphleon/TeaTimer">on GitHub</a></b>.</p>
+				<p>Divine Timer is a fork of the open source TeaTimer app by Ralph Gootee, which is also available <b><a href="https://github.com/ralphleon/TeaTimer">on GitHub</a></b>.</p>
 				<p>The Enso image was drawn by Ryōnen Gensō (1646-1711). Next to the Enso she has written:<br>
                     "When you do understand yourself fully,<br>
                     there is not one thing."<br><br>
@@ -162,14 +162,17 @@
     <string name="show_system_settings_desc">Notifications can be customized in Android System Settings</string>
     <string name="do_not_disturb">Do not Disturb</string>
     <string name="do_not_disturb_desc">Enter "Do Not Disturb" Mode when meditating</string>
-    <string name="open_timer">Open BodhiTimer</string>
+    <string name="open_timer">Open DivineTimer</string>
     <string name="service_channel_name">Service</string>
-    <string name="service_channel_description">Notification that Bodhi Timer is running</string>
+    <string name="service_channel_description">Notification that Divine Timer is running</string>
     <string name="service_text">This notification ensures correct playback of your timer tones</string>
     <string name="use_old_notification">Use old Notification Method</string>
     <string name="use_old_notification_desc">If you experience crashes or unreliable alarms, try to check this.</string>
     <string name="tab_timer">Timer</string>
     <string name="tab_info">Prayer</string>
+    <string name="tab_calendar">Calendar</string>
+    <string name="log_added">Session logged</string>
+    <string name="log_removed">Log removed</string>
   <string name="info_paragraphs">
 FATHER-MOTHER-LIFE\n\n
 You are my life, my constant support, my health, my protection, my perfect fulfilment of every need and my highest inspiration.\n\n

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -1,6 +1,6 @@
 # Advanced Usage
 
-This page provides additional information about using Bodhi Timer beyond the basic instructions in the main README.
+This page provides additional information about using Divine Timer beyond the basic instructions in the main README.
 
 ## Voice commands
 

--- a/fastlane/metadata/android/en-US/full_description-uni.txt
+++ b/fastlane/metadata/android/en-US/full_description-uni.txt
@@ -1,5 +1,5 @@
 <h1 id="about"><b>About</b></h1>
-<p>Bodhi Timer is an elegant, minimalist countdown timer. It is designed mainly for use as a meditation timer but can easily be used for any similar purpose. Bodhi Timer is free and <a href="https://github.com/yuttadhammo/BodhiTimer">open-source</a> software. It collects no data and uses the minimal permissions necessary.</p>
+<p>Divine Timer is an elegant, minimalist countdown timer. It is designed mainly for use as a meditation timer but can easily be used for any similar purpose. Divine Timer is free and <a href="https://github.com/yuttadhammo/DivineTimer">open-source</a> software. It collects no data and uses the minimal permissions necessary.</p>
 
 <h2 id="how-to-use"><b>How to use</b></h2>
 💠 Set the time via the clock icon in the top left. You may set presets by choosing a time then holding down on one of the three preset buttons.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,7 @@
 <h1 id="about"><b>About</b></h1>
-<p>Bodhi Timer is an elegant, minimalist countdown timer.
+<p>Divine Timer is an elegant, minimalist countdown timer.
 It is designed mainly for use as a meditation timer but can easily be used for any similar purpose.
-This app is developed as <a href="https://github.com/yuttadhammo/BodhiTimer">open-source</a> software.
+This app is developed as <a href="https://github.com/yuttadhammo/DivineTimer">open-source</a> software.
 It collects no data and uses the minimal permissions necessary.</p>
 
 <h2 id="how-to-use"><b>How to use</b></h2>

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Bodhi Timer
+Divine Timer


### PR DESCRIPTION
## Summary
- add MeditationLog utility to keep track of daily meditation
- log completed sessions in AlarmTaskManager
- add CalendarView layout and navigation tab
- handle calendar tab selection in TimerActivity
- replace all occurrences of "Bodhi Timer" with "Divine Timer" across the project
- ensure calendar is visible on dark background

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68423e0e18208320817dca96e5186a05